### PR TITLE
Fixes #2. Upgrade command-line-args to 4.x version, 1.x has deprecated dependencies

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 var commandLineArgs = require("command-line-args")
-  , colors = require('colors')
-  , cli = commandLineArgs([
-    { name: "port", alias: "P", type: Number, defaultValue: 3000 },
-    { name: "allowCORS", alias: "C", type: Boolean, defaultValue: false },
-    { name: "help", alias: "H", type: Boolean, defaultValue: false }
-  ])
-  , directory = process.argv[2] || "."
-  , usage = cli.getUsage()
-  , options = cli.parse()
+, colors = require('colors')
+, options = commandLineArgs([
+  { name: "port", alias: "P", type: Number, defaultValue: 3000 },
+  { name: "allowCORS", alias: "C", type: Boolean, defaultValue: false },
+  { name: "help", alias: "H", type: Boolean, defaultValue: false }
+])
+, directory = process.argv[2] || "."
+, commandLineUsage = require('command-line-usage')
+, usage = commandLineUsage(/*templateData*/)
   ;
 
 if(options.help){

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "license": "MIT",
   "dependencies": {
     "colors": "^1.1.2",
-    "command-line-args": "^1.0.0",
+    "command-line-args": "^4.0.7",
+    "command-line-usage": "^4.0.1",
     "lodash": "^3.10.0",
     "q": "^1.4.1"
   },


### PR DESCRIPTION
Command-line-args 1.x uses a deprecated package:
https://www.npmjs.com/package/column-layout

In order to fix it, you have to upgrade to 4.x version, that has breaking changes from 3.x version:
https://github.com/75lb/command-line-args/releases/tag/v3.0.0

Applied into this PR.